### PR TITLE
stop travis from checking in JDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false # faster builds
 
 jdk:
   - openjdk8
-  - openjdk11
   
 script: "mvn cobertura:cobertura"
 


### PR DESCRIPTION
I believe that trying to support both JDK8 and JDK11 is going to be costly. If we decided for JDK8 we should only stick to that… Let me know if you agree :)