### PR TITLE
Fix missing import statement in Main.java

### DIFF
--- a/src/main/java/com/worldwarofants/game/Main.java
+++ b/src/main/java/com/worldwarofants/game/Main.java
@@ -1,5 +1,7 @@
 package com.worldwarofants.game;
 
+import com.worldwarofants.game.ConsoleGame;
+
 public class Main {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Main.java attempts to use a class that it doesn't know of because it was never imported. Sometimes it works, sometimes it doesn't. I don't know why Java is doing that.
This PR fixes that, making the import statement explicit instead of implicit.