### PR TITLE
Enable Maven build as Github Action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn package --file pom.xml


### PR DESCRIPTION
This should allow us to use the Github's new automatic build feature.
It isn't strictly needed as we already have Travis CI set up, but it's nice to have redundancy in systems like these - it doesn't cost us anything, and it's helpful to have more checks.